### PR TITLE
feat(Connection): implement IRequest in all Connection open and send methods

### DIFF
--- a/src/IRequest.js
+++ b/src/IRequest.js
@@ -1,20 +1,22 @@
 import {assert} from 'assert';
 
-var IRequest = assert.define('IRequest', function(value) {
-  var value;
-  //Assume it's a class, check its prototype
-  if (value instanceof Function) {
-    value = value.prototype;
+var XHRDataTypes = assert.define('XHRDataTypes', (value) => {
+  if (value instanceof Document) {
+    //pass
+    //related to issue https://github.com/angular/assert/issues/5
   }
   else {
-    value = value;
+    assert(value).is(DataView, Blob, Document, assert.string, FormData);
   }
+});
 
-  assert(value).is(assert.structure({
-    responseType: assert.string,
+var IRequest = assert.define('IRequest', function(value) {
+  assert.type(value, assert.structure({
+    url: assert.string,
     method: assert.string,
+    data: XHRDataTypes,
+    responseType: assert.string,
     params: Map,
-    data: assert.string,
     headers: Map
   }));
 

--- a/src/XHRConnection.js
+++ b/src/XHRConnection.js
@@ -1,17 +1,8 @@
 import {Inject} from 'di/annotations';
 import {Injector} from 'di/injector';
 import {Deferred} from 'prophecy/Deferred';
+import {IRequest} from './IRequest';
 import {assert} from 'assert';
-
-var XHRDataTypes = assert.define('XHRDataTypes', (value) => {
-  if (value instanceof Document) {
-    //pass
-    //related to issue https://github.com/angular/assert/issues/5
-  }
-  else {
-    assert(value).is(DataView, Blob, Document, assert.string, FormData);
-  }
-});
 
 /**
  * Manages state of a single connection
@@ -56,12 +47,12 @@ export class XHRConnection {
     this.deferred.reject(evt);
   }
 
-  open (method:string, url:string) {
+  open (req:IRequest) {
     if (this.xhr_.readyState === 1) {
       throw new Error('Connection is already open');
     }
-    this.method = method;
-    this.url = url;
+    this.method = req.method;
+    this.url = req.url;
     this.xhr_.open(this.method, this.url);
   }
 
@@ -69,13 +60,10 @@ export class XHRConnection {
     this.xhr_.setRequestHeader(key, value);
   }
 
-  send (data) {
+  send (req:IRequest) {
     this.xhr_.addEventListener('load', this.onLoad_.bind(this));
     this.xhr_.addEventListener('error', this.onError_.bind(this));
-    if (typeof data !== 'undefined') {
-      assert.type(data, XHRDataTypes);
-    }
 
-    this.xhr_.send(data);
+    this.xhr_.send(req.data);
   }
 }

--- a/test/ConnectionMock.spec.js
+++ b/test/ConnectionMock.spec.js
@@ -7,7 +7,16 @@ import {inject, use} from 'di/testing';
 import {PromiseBackend} from 'prophecy/PromiseMock';
 
 describe('ConnectionMockBackend', function() {
+  var sampleRequest;
   beforeEach(function() {
+    sampleRequest = {
+      method: 'GET',
+      url: '/users',
+      responseType: '',
+      data: '',
+      params: new Map(),
+      headers: new Map()
+    };
     PromiseBackend.patchWithMock();
   });
 
@@ -69,8 +78,8 @@ describe('ConnectionMockBackend', function() {
             ConnectionMockBackend.whenRequest('GET', '/users').respond(200, 'User!');
             var connection = new ConnectionMock();
             var resolveSpy = spyOn(connection.deferred, 'resolve').and.callThrough();
-            connection.open('GET', '/users');
-            connection.send();
+            connection.open(sampleRequest);
+            connection.send(sampleRequest);
             ConnectionMockBackend.flush();
             expect(resolveSpy).toHaveBeenCalledWith('User!');
           });
@@ -83,7 +92,7 @@ describe('ConnectionMockBackend', function() {
         ConnectionMockBackend.whenRequest('GET', '/users').respond(200, 'User!');
         var connection = new ConnectionMock();
         var resolveSpy = spyOn(connection.deferred, 'resolve').and.callThrough();
-        connection.open('GET', '/users');
+        connection.open(sampleRequest);
         expect(ConnectionMockBackend.flush).toThrow();
         expect(resolveSpy).not.toHaveBeenCalled();
       });
@@ -96,8 +105,8 @@ describe('ConnectionMockBackend', function() {
         ConnectionMockBackend.whenRequest('GET', '/users').respond(400, 'Not Found');
         var connection = new ConnectionMock();
         var rejectSpy = spyOn(connection.deferred, 'reject').and.callThrough();
-        connection.open('GET', '/users');
-        connection.send();
+        connection.open(sampleRequest);
+        connection.send(sampleRequest);
         ConnectionMockBackend.flush();
         expect(rejectSpy).toHaveBeenCalledWith('Not Found');
       });
@@ -157,6 +166,19 @@ describe('ConnectionMockBackend', function() {
 
 
 describe('ConectionMock', function() {
+  var sampleRequest;
+
+  beforeEach(function() {
+    sampleRequest = {
+      method: 'GET',
+      url: '/users',
+      responseType: '',
+      data: '',
+      params: new Map(),
+      headers: new Map()
+    };
+  });
+
   afterEach(function() {
     delete ConnectionMockBackend.connections;
   });
@@ -179,23 +201,25 @@ describe('ConectionMock', function() {
       var connection = new ConnectionMock();
       expect(connection.method).toBeUndefined();
       expect(connection.url).toBeUndefined();
-      connection.open('GET', '/users');
+      connection.open(sampleRequest);
       expect(connection.method).toBe('GET');
       expect(connection.url).toBe('/users');
     });
 
     it('should complain if method is not a string', function() {
       var connection = new ConnectionMock();
+      sampleRequest.method = undefined;
       expect(function() {
-        connection.open(undefined, '/users');
+        connection.open(sampleRequest);
       }).toThrow();
     });
 
 
     it('should complain if url is not a string', function() {
       var connection = new ConnectionMock();
+      sampleRequest.url = undefined;
       expect(function() {
-        connection.open('GET', undefined);
+        connection.open(sampleRequest);
       }).toThrow();
     });
   });
@@ -205,19 +229,21 @@ describe('ConectionMock', function() {
     it('should add the connection to mock backend connections list', function() {
       var connection = new ConnectionMock();
       expect(ConnectionMockBackend.connections).toBeUndefined();
-      connection.open('GET', '/items');
+      connection.open(sampleRequest);
       expect(ConnectionMockBackend.connections).toBeUndefined();
-      connection.send();
+      connection.send(sampleRequest);
       expect(ConnectionMockBackend.connections.length).toBe(1);
     });
 
 
     it('should attach the data to the connection instance', function() {
-      var data = 'New Item';
       var connection = new ConnectionMock();
-      connection.open('POST', '/items');
-      connection.send(data);
-      expect(connection.data).toBe(data);
+      sampleRequest.data = 'New Item';
+      sampleRequest.method = 'POST';
+      sampleRequest.url = '/items';
+      connection.open(sampleRequest);
+      connection.send(sampleRequest);
+      expect(connection.data).toBe('New Item');
     });
   });
 

--- a/test/Http.spec.js
+++ b/test/Http.spec.js
@@ -157,7 +157,6 @@ describe('Http', function() {
         ConnectionClass: ConnectionMock
       }).then(spy);
       PromiseBackend.flush(true);
-      ConnectionMockBackend.flush();
       expect(spy).toHaveBeenCalled();
       expect(spy.calls.count()).toBe(2);
     });
@@ -172,7 +171,6 @@ describe('Http', function() {
         ConnectionClass: ConnectionMock
       });
       PromiseBackend.flush(true);
-      ConnectionMockBackend.flush(true);
       expect(spy.calls.count()).toBe(2);
     });
 

--- a/test/IRequest.spec.js
+++ b/test/IRequest.spec.js
@@ -5,12 +5,23 @@ describe('IRequest', function() {
   var basicRequest;
   beforeEach(function(){
     basicRequest = {
+      url: '/users',
       responseType: 'json',
       method: 'get',
       params: new Map(),
       data: '',
       headers: new Map()
     }
+  });
+
+
+  it('should complain if url is missing', function() {
+    delete basicRequest.url;
+    expect(function() {
+      assert.type(basicRequest, IRequest);
+    }).toThrow();
+    basicRequest.url = '/users';
+    assert.type(basicRequest, IRequest);
   });
 
 
@@ -51,6 +62,52 @@ describe('IRequest', function() {
     }).toThrow();
     basicRequest.data = 'foo';
     assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should accept DataView data', function() {
+    var buffer = new ArrayBuffer();
+    basicRequest.method = 'POST';
+    basicRequest.data = new DataView(buffer);
+    assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should accept Blob data', function() {
+    basicRequest.data = new Blob();
+    basicRequest.method = 'POST';
+    assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should accept Document data', function() {
+    basicRequest.data = document.implementation.createDocument(null, 'doc');
+    basicRequest.method = 'POST';
+    assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should accept String data', function() {
+    basicRequest.data = 'POST ME!';
+    basicRequest.method = 'POST';
+    assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should accept FormData data', function() {
+    basicRequest.data = new FormData();
+    basicRequest.data.append('user', 'Jeff');
+    basicRequest.method = 'POST';
+    assert.type(basicRequest, IRequest);
+  });
+
+
+  it('should complain when given an invalid type of data', function() {
+    basicRequest.method = 'POST';
+    basicRequest.data = 5;
+    expect(function() {
+      assert.type(basicRequest, IRequest);
+    }).toThrow();
   });
 
 

--- a/test/XHRConnection.spec.js
+++ b/test/XHRConnection.spec.js
@@ -5,6 +5,19 @@ import {inject} from 'di/testing';
 import {PromiseBackend, PromiseMock} from 'prophecy/PromiseMock';
 
 describe('XHRConnection', function() {
+  var sampleRequest;
+
+  beforeEach(function() {
+    sampleRequest = {
+      method: 'GET',
+      url: '/users',
+      responseType: '',
+      data: '',
+      params: new Map(),
+      headers: new Map()
+    };
+  });
+
   it('should implement IConnection', function() {
     assert.type(XHRConnection, IConnection);
   });
@@ -20,54 +33,39 @@ describe('XHRConnection', function() {
   describe('.open()', function() {
     it('should complain if no method provided', function() {
       var connection = new XHRConnection();
+      sampleRequest.method = undefined;
       expect(function() {
-        connection.open(undefined, '/users');
+        connection.open(sampleRequest);
       }).toThrow();
     });
 
-    it('should complain if provided method is not a string', function() {
+    it('should complain if provided method is not passed a valid request', function() {
       expect(function() {
         var connection = new XHRConnection();
-        connection.open(undefined, '/users');
-      }).toThrow();
-      expect(function() {
-        var connection = new XHRConnection();
-        connection.open('GET', '/users');
-      }).not.toThrow();
+        connection.open({});
+      }).toThrowError(/to be an instance of IRequest/);
     });
 
 
     it('should set the method to the instance', function() {
       var connection = new XHRConnection();
-      connection.open('GET', '/users');
+      connection.open(sampleRequest);
       expect(connection.method).toBe('GET');
-    });
-
-
-    it('should complain if invalid url type provided', function() {
-      expect(function() {
-        var connection = new XHRConnection();
-        connection.open('GET', undefined);
-      }).toThrow();
-      expect(function() {
-        var connection = new XHRConnection();
-        connection.open('GET', '/users');
-      }).not.toThrow();
     });
 
 
     it('should set the url to the instance', function () {
       var connection = new XHRConnection();
-      connection.open('GET', '/items');
-      expect(connection.url).toBe('/items');
+      connection.open(sampleRequest);
+      expect(connection.url).toBe('/users');
     });
 
 
     it('should complain if open is called more than once', function() {
       var connection = new XHRConnection();
-      connection.open('GET', '/items');
+      connection.open(sampleRequest);
       expect(function() {
-        connection.open('GET', '/items');
+        connection.open(sampleRequest);
       }).toThrow();
     });
   });
@@ -82,76 +80,20 @@ describe('XHRConnection', function() {
     it('should add load and error event listeners', function() {
       var listenerSpy = spyOn(XMLHttpRequest.prototype, 'addEventListener');
       var connection = new XHRConnection();
-      connection.open('GET', '/items');
+      connection.open(sampleRequest);
       expect(listenerSpy).not.toHaveBeenCalled();
-      connection.send();
+      connection.send(sampleRequest);
       expect(listenerSpy.calls.all()[1].args[0]).toBe('error');
       expect(listenerSpy.calls.all()[0].args[0]).toBe('load');
     });
 
 
-    it('should accept no data', function() {
+    it('should complain if not given a valid IRequest type', function() {
       var connection = new XHRConnection();
-      connection.open('POST', '/assets');
-      connection.send();
-      expect(sendSpy).toHaveBeenCalled();
-    });
-
-
-    it('should accept DataView data', function() {
-      var buffer = new ArrayBuffer();
-      var view = new DataView(buffer);
-      var connection = new XHRConnection();
-      connection.open('POST', '/assets');
-      connection.send(view);
-      expect(sendSpy).toHaveBeenCalledWith(view);
-    });
-
-
-    it('should accept Blob data', function() {
-      var blob = new Blob();
-      var connection = new XHRConnection();
-      connection.open('POST', '/assets');
-      connection.send(blob);
-      expect(sendSpy).toHaveBeenCalledWith(blob);
-    });
-
-
-    it('should accept Document data', function() {
-      var connection = new XHRConnection();
-      var doc = document.implementation.createDocument(null, 'doc');
-      connection.open('POST', '/assets');
-      connection.send(doc);
-      expect(sendSpy).toHaveBeenCalledWith(doc);
-    });
-
-
-    it('should accept String data', function() {
-      var connection = new XHRConnection();
-      var body = 'POST ME!';
-      connection.open('POST', '/assets');
-      connection.send(body);
-      expect(sendSpy).toHaveBeenCalledWith(body);
-    });
-
-
-    it('should accept FormData data', function() {
-      var connection = new XHRConnection();
-      var formData = new FormData();
-      formData.append('user', 'Jeff');
-      connection.open('POST', '/assets');
-      connection.send(formData);
-      expect(sendSpy).toHaveBeenCalledWith(formData);
-    });
-
-
-    it('should complain when given an invalid type of data', function() {
-      var connection = new XHRConnection();
-      connection.open('POST', '/assets');
+      connection.open(sampleRequest);
       expect(function() {
-        connection.send(5);
+        connection.send({});
       }).toThrow();
-
     });
   });
 
@@ -177,8 +119,8 @@ describe('XHRConnection', function() {
       var removedListenerSpy = spyOn(XMLHttpRequest.prototype, 'removeEventListener');
       var sendSpy = spyOn(XMLHttpRequest.prototype, 'send');
       var connection = new XHRConnection();
-      connection.open('GET', '/items');
-      connection.send();
+      connection.open(sampleRequest);
+      connection.send(sampleRequest);
       expect(addListenerSpy.calls.count()).toBe(2);
       expect(removedListenerSpy).not.toHaveBeenCalled();
       connection.onLoad_({});
@@ -205,8 +147,8 @@ describe('XHRConnection', function() {
       var removedListenerSpy = spyOn(XMLHttpRequest.prototype, 'removeEventListener');
       var sendSpy = spyOn(XMLHttpRequest.prototype, 'send');
       var connection = new XHRConnection();
-      connection.open('GET', '/items');
-      connection.send();
+      connection.open(sampleRequest);
+      connection.send(sampleRequest);
       expect(addListenerSpy.calls.count()).toBe(2);
       expect(removedListenerSpy).not.toHaveBeenCalled();
       connection.onError_({});

--- a/test/mocks/ConnectionMock.js
+++ b/test/mocks/ConnectionMock.js
@@ -1,5 +1,7 @@
+import {assert} from 'assert';
 import {Deferred} from 'prophecy/Deferred';
 import {IConnection} from '../../src/IConnection';
+import {IRequest} from '../../src/IRequest';
 import {PromiseBackend} from 'prophecy/PromiseMock';
 
 export class ResponseMap extends Map {
@@ -88,13 +90,13 @@ export class ConnectionMock {
     this.deferred = new Deferred();
   }
 
-  open(method:string, url:string) {
-    this.method = method;
-    this.url = url;
+  open(req:IRequest) {
+    this.method = req.method;
+    this.url = req.url;
   }
 
-  send(data) {
-    this.data = data;
+  send(req:IRequest) {
+    this.data = req.data;
     ConnectionMockBackend.addConnection(this);
   }
 


### PR DESCRIPTION
The IRequest diff is misleading from lines 3-12. I removed the block that was checking if the value had a prototype, and added the XHRDataTypes definition where it was.

Much of the validation testing was moved from XHRConnection.spec.js to IRequest.spec.js since that is where the validation occurs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/http/38)
<!-- Reviewable:end -->
